### PR TITLE
Simple text changes and link updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ $ GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+
+### Edits and updates
+
+Make changes on a feature branch; submit a Pull Request into the `develop` branch.

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ If you are using GitHub pages for hosting, this command is a convenient way to b
 
 ### Edits and updates
 
-Make changes on a feature branch; submit a Pull Request into the `develop` branch.
+Make changes on a feature branch; submit a Pull Request into the `staging` branch.

--- a/docs/client-instructions.md
+++ b/docs/client-instructions.md
@@ -10,7 +10,7 @@ The raid party lead is responsible for working with the client to help them make
 
 If you are paying Raid Guild from an EOA like MetaMask, follow these instructions:
 
-1. Go to https://xdai.escrow.raidguild.org/escrow/[RaidID] -- _[raid party lead: replace [RaidID] with the RaidID from Airtable]_
+1. Go to https://smartescrow.raidguild.org/escrow/[RaidID] -- _[raid party lead: replace [RaidID] with the RaidID from Airtable]_
 2. Connect your MetaMask or WalletConnect wallet
 3. Follow the instructions to deposit. There will be 2 transactions - the first to approve the Raid Guid Escrow contract to transfer your tokens, and the second to make the deposit itself.
 4. Refresh to verify that the deposit has been made (you may need to reconnect your wallet).

--- a/docs/discord-bots.md
+++ b/docs/discord-bots.md
@@ -24,20 +24,6 @@ Here's a link to [Collab.land](https://collab.land/) if you'd like to learn more
 
 <iframe width="100%" height="500" src="https://www.youtube.com/embed/fiVEyVsR7k8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-## Groovy
-
-Groovy is a music playing bot.
-
-> Groovy is the quickest way to turn your Discord server into the big stage. Whether you're an upcoming artist, a super star, or a hobby DJ: Sharing music through Discord has never been easier. -[https://groovy.bot/](https://groovy.bot/)
-
-A list of of Groovy commands can be seen below:
-
-<iframe src="https://groovy.bot/commands/" frameborder="0" sandbox="allow-scripts allow-popups allow-top-navigation-by-user-activation allow-forms allow-same-origin" allowfullscreen="" loading="lazy" width='100%' height='500'></iframe>
-
-[https://groovy.bot/commands](https://groovy.bot/commands)
-
-[https://groovy.zendesk.com/hc/en-us/articles/360060721952](https://groovy.zendesk.com/hc/en-us/articles/360060721952)
-
 ## Friend Time
 
 With Friend Time you can easily coordinate times between users.
@@ -109,16 +95,6 @@ Made possible by @luigy 𝗹𝗲𝗺𝗼𝗻
 [https://sesh.fyi/manual/](https://sesh.fyi/manual/)
 
 <iframe src="https://sesh.fyi/manual/" frameborder="0" sandbox="allow-scripts allow-popups allow-top-navigation-by-user-activation allow-forms allow-same-origin" allowfullscreen="" loading="lazy" width='100%' height='500'></iframe>
-
-## Suggestion Bot.
-
-Suggestion bot is a way to submit suggestions or thoughts on how to improve the community. It has anonymity built into it to further support the idea that all participants are welcome and are encouraged to share their input.
-
-To engage, DM the bot:
-
-```jsx
-!suggest <anonymous message>
-```
 
 ## Haus Bot
 

--- a/docs/discord-bots.md
+++ b/docs/discord-bots.md
@@ -100,7 +100,7 @@ Made possible by @luigy 𝗹𝗲𝗺𝗼𝗻
 
 This bot is operating on Raid Guild discord channels #dao-verified, #uh-notifications and #haus-of-daos for the convenience of DAO Haus and UBERHAUS in order to keep track of incoming member proposals. It contains variables such as:
 
-- the name fo the proposal
+- the name of the proposal
 - a short description of the proposal
 - the amount of member shares
 - the tribute amount of WXDAI

--- a/docs/discord-getting-started.md
+++ b/docs/discord-getting-started.md
@@ -5,7 +5,7 @@ sidebar_label: Getting Started
 ---
 You can join the Discord [here](https://discord.gg/RWjkQ6DNnv), If you have been assigned a “Raid Guild Member” role, then you will be able to access all of Raid Guild’s internal channels. 
 
-If you are **not** a Raid Guild member, we recommend you check out `[Becoming An Apprentice](https://handbook.raidguild.org/docs/discord-getting-started)` first.  If admitted to the Raid Guild as an apprentice, you’ll have the opportunity to prove your talent and level up in the DAO as you complete tasks, unlocking access to new private channels.  This will allow you to take on bigger Raids and contribute to shaping the Guild as we know it today.
+If you are **not** a Raid Guild member, we recommend you check out “[Become An Apprentice](https://handbook.raidguild.org/docs/become-an-apprentice)” first.  If admitted to the Raid Guild as an apprentice, you’ll have the opportunity to prove your talent and level up in the DAO as you complete tasks, unlocking access to new private channels.  This will allow you to take on bigger Raids and contribute to shaping the Guild as we know it today.
 
 ### Starting in Discord
 

--- a/docs/discord-getting-started.md
+++ b/docs/discord-getting-started.md
@@ -9,7 +9,7 @@ If you are **not** a Raid Guild member, we recommend you check out “[Become An
 
 ### Starting in Discord
 
-If you haven't already introduced yourself, the first place you’ll want to make yourself known is <span class='channels'>#Tavern</span> - where you can introduce yourself, your hobbies and your strengths.
+If you haven't already introduced yourself, the first place you’ll want to make yourself known is <span class='channels'>#tavern</span> - where you can introduce yourself, your hobbies and your strengths.
 
 From here, you’ll want to start earning some rep in the Guild by tackling open Apprentice issues in the <span class='channels'>#projects</span> channel.
 

--- a/docs/discord-getting-started.md
+++ b/docs/discord-getting-started.md
@@ -3,7 +3,7 @@ id: discord-getting-started
 title: Getting Started
 sidebar_label: Getting Started
 ---
-You can join the Discord [here](https://discord.gg/RWjkQ6DNnv), If you have been assigned a “Raid Guild Member” role, then you will be able to access all of Raid Guild’s internal channels. 
+You can join the Raid Guild Discord [here](https://discord.gg/RWjkQ6DNnv). When you have been assigned a “Raid Guild Member” role, then you will be able to access all of Raid Guild’s internal channels. 
 
 If you are **not** a Raid Guild member, we recommend you check out “[Become An Apprentice](https://handbook.raidguild.org/docs/become-an-apprentice)” first.  If admitted to the Raid Guild as an apprentice, you’ll have the opportunity to prove your talent and level up in the DAO as you complete tasks, unlocking access to new private channels.  This will allow you to take on bigger Raids and contribute to shaping the Guild as we know it today.
 

--- a/docs/happy-path.md
+++ b/docs/happy-path.md
@@ -6,7 +6,7 @@ sidebar_label: Happy Path
 
 > :warning:&nbsp; **WARNING:** Never send funds (tokens or ETH) directly to the escrow smart contract. Those funds will not be recoverable.
 
-1. Raid party lead (i.e., <span id='monk'>Cleric</span> or <span id='monk'>Monk</span>) [creates an escrow](https://smartescrow.raidguild.org/) for the raid, with the following info:
+1. Raid party lead (i.e., <span id='cleric'>Cleric</span> or <span id='monk'>Monk</span>) [creates an escrow](https://smartescrow.raidguild.org/) for the raid, with the following info:
     - **Raid party multisig address** (xDAI Gnosis Safe Address)
     - **The client's address**
     - **Total payment amount**

--- a/docs/happy-path.md
+++ b/docs/happy-path.md
@@ -6,7 +6,7 @@ sidebar_label: Happy Path
 
 > :warning:&nbsp; **WARNING:** Never send funds (tokens or ETH) directly to the escrow smart contract. Those funds will not be recoverable.
 
-1. Raid party lead (i.e., <span id='monk'>Cleric</span> or <span id='monk'>Monk</span>) [creates an escrow](https://xdai.escrow.raidguild.org/) for the raid, with the following info:
+1. Raid party lead (i.e., <span id='monk'>Cleric</span> or <span id='monk'>Monk</span>) [creates an escrow](https://smartinvoice.xyz/) for the raid, with the following info:
     - **Raid party multisig address** (xDAI Gnosis Safe Address)
     - **The client's address**
     - **Total payment amount**

--- a/docs/happy-path.md
+++ b/docs/happy-path.md
@@ -6,7 +6,7 @@ sidebar_label: Happy Path
 
 > :warning:&nbsp; **WARNING:** Never send funds (tokens or ETH) directly to the escrow smart contract. Those funds will not be recoverable.
 
-1. Raid party lead (i.e., <span id='monk'>Cleric</span> or <span id='monk'>Monk</span>) [creates an escrow](https://smartinvoice.xyz/) for the raid, with the following info:
+1. Raid party lead (i.e., <span id='monk'>Cleric</span> or <span id='monk'>Monk</span>) [creates an escrow](https://smartescrow.raidguild.org/) for the raid, with the following info:
     - **Raid party multisig address** (xDAI Gnosis Safe Address)
     - **The client's address**
     - **Total payment amount**

--- a/docs/references.md
+++ b/docs/references.md
@@ -4,8 +4,8 @@ title: References
 sidebar_label: References
 ---
 
--   Raid Guild Escrow home page: https://xdai.escrow.raidguild.org/
--   Direct link to a specific raid escrow: `https://xdai.escrow.raidguild.org/escrow/[raidID]`
+-   Raid Guild Escrow home page: https://smartescrow.raidguild.org/
+-   Direct link to a specific raid escrow: `https://smartescrow.raidguild.org/[raidID]`
 -   LexGuildLocker contract: [0x7f8F6E42C169B294A384F5667c303fd8Eedb3CF3](https://blockscout.com/poa/xdai/address/0x7f8F6E42C169B294A384F5667c303fd8Eedb3CF3/contracts)
 
 > :warning:&nbsp; **WARNING:** Never send funds (ERC20 tokens or xDAI) directly to the escrow smart contract. Those funds will not be recoverable.


### PR DESCRIPTION
Squashing into one commit

**Easy fixes of handbook updates** 
ref. 
- https://hackmd.io/@t_IcjdBBSYWEo4jZ-hJ35A/BkhsF2gXq
- https://github.com/raid-guild/RIPs/issues/85

Text update: Fix the apprentice link, update some text on https://handbook.raidguild.org/docs/discord-getting-started

Removed the section on Groovy Bot and Sentry Bot and fix a typo on Discord Bots page  
[https://handbook.raidguild.org/docs/discord-bots](https://handbook.raidguild.org/docs/discord-bots#groovy)

Update the links to the escrow site on docs/client-instructions.md, docs/happy-path.md, docs/references.md
Was https://xdai.escrow.raidguild.org, now https://smartescrow.raidguild.org/)

Add jp’s notes on updates and edits and PRs to README.md